### PR TITLE
Schema 체크용 Github Action 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: Check Schema
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    env:
+      ScriptPath: tools.py
+      
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check Schema
+        id: cleanup
+        run: |
+          python $ScriptPath check-all

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,112 @@
+import json, os, sys
+from os import path
+
+PATH_ROOT = os.getcwd()
+PATH_CONTESTS = path.join(PATH_ROOT, "contests.json")
+
+def check_schema(file_path):
+    if not path.exists(file_path):
+        print("Input file doesn't exist.")
+        return False
+    try:
+        js = json.load(open(file_path, 'r', encoding='utf-8'))
+        if not js: raise Exception("Empty JSON file.")
+
+        duration = js['duration']; ensure_type(duration, int)
+        contestants = js['contestants']; ensure_type(contestants, list)
+        problems = js['problems']; ensure_type(problems, list)
+        standings = js['standings']; ensure_type(standings, list)
+
+
+        # contestant_dict = dict()
+        for contestant in filter(lambda x: ensure_type(x, dict), contestants):
+            contestant_id = int(contestant['contestant_id'])
+            contestant_name = contestant['contestant_name']; ensure_type(contestant_name, str)
+            # contestant_dict[contestant_id] = contestant_name
+
+        problem_dict = dict()
+        for problem in filter(lambda x: ensure_type(x, dict), problems):
+            problem_id = problem['problem_id']; ensure_type(problem_id, str)
+            problem_name = problem['problem_name']; ensure_type(problem_name, str)
+            problem_dict[problem_id] = problem_name
+
+        for standing in filter(lambda x: ensure_type(x, dict), standings):
+            contestant_id = int(standing['contestant_id'])
+            contestant_name = standing['contestant_name']; ensure_type(contestant_name, str)
+            solve = standing['solve']; ensure_type(solve, int)
+            penalty = standing['penalty']; ensure_type(penalty, int)
+            judge = standing['judge']; ensure_type(judge, list)
+
+            # ensure_eq(contestant_dict[contestant_id], contestant_name)
+            ensure_eq(len(judge), len(problem_dict))
+            summation = 0
+            for j in judge:
+                ensure_type(j, dict)
+                problem_id = j['problem_id']; ensure_type(problem_id, str)
+                problem_name = j['problem_name']; ensure_type(problem_name, str)
+                status = j['status']; ensure_type(status, str | None)
+                submission = j['submission']; ensure_type(submission, int)
+                time = j['time']; ensure_type(time, int | None)
+                j_penalty = j['penalty']; ensure_type(j_penalty, int | None)
+
+                ensure_eq(problem_dict[problem_id], problem_name)
+                if status is not None:
+                    ensure(status in ['accepted', 'wronganswer'], f"Invalid status: {status}")
+                if time is not None:
+                    # ensure(0 <= time <= duration, f"Invalid time: {time}")
+                    ensure(0 <= time, f"Invalid time: {time}")
+                summation += j_penalty if j_penalty is not None else 0
+
+            # ensure_eq(penalty, summation)
+        return True
+    except Exception as e:
+        print("Invalid JSON schema. Reason:", e)
+        return False
+
+def read_contests():
+    try:
+        js = json.load(open(PATH_CONTESTS, 'r', encoding='utf-8'))
+        if not js: raise Exception("Empty JSON file.")
+        return js
+    except Exception as e:
+        print("Invalid JSON schema. Reason:", e)
+        return None
+
+def ensure_type(obj, t):
+    if not isinstance(obj, t):
+        raise Exception(f"Invalid {t.__name__} object.")
+    return True
+
+def ensure_eq(a, b):
+    if a != b:
+        raise Exception(f"Expected {a} to be equal to {b}.")
+    return True
+
+def ensure(exp, msg):
+    if not exp:
+        raise Exception(msg)
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Invalid command.")
+        quit(1)
+    if sys.argv[1] == "check":
+        input_file = sys.argv[2]
+        if check_schema(input_file):
+            print("Valid JSON schema.")
+            quit(0)
+        else:
+            quit(1)
+    if sys.argv[1] == "check-all":
+        contests = read_contests()
+        for contest in contests:
+            print(f"Checking {contest['contest_name']}...")
+            if not check_schema(contest['location']):
+                quit(1)
+        print("All contests are valid.")
+
+    else:
+        print("Invalid command.")
+        quit(1)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b6f8c78c-8dd7-4c40-8728-874aab32ae0b)

대회 정보 파일들을 읽어서 올바른 schema인지 검사합니다.

- `contests.json`에 기록된 대회들의 json 파일을 검사합니다.
- 각 json 파일에 대해 필드 존재 유무, 타입 체크 등을 진행합니다.
![image](https://github.com/user-attachments/assets/29f4f81a-d53e-42f8-9c74-ad48bd8d26c9)
- 잘못된 파일이 존재할 경우 위와 같은 에러 메시지를 남기고 에러코드 1로 종료됩니다.

- 사용 예시
  - `python tools.py check test.json`: `test.json`이 올바른 schema인지 검사합니다.
  - `python tools.py check-all`: `contests.json`에 기록된 대회들이 모두 올바른 schema인지 검사합니다.